### PR TITLE
Minor update (changed URL)

### DIFF
--- a/src/getVideoUrl.js
+++ b/src/getVideoUrl.js
@@ -42,7 +42,7 @@ async function getVideoUrl(url) {
 	let response;
 
 	try {
-		response = (await got.post("https://fbdown.net/download.php", {
+		response = (await got.post("https://fdown.net/download.php", {
 		  body: form
 		})).body;
 	} catch (e) {


### PR DESCRIPTION
fbdown.net is now just [fdown.net](https://fdown.net)